### PR TITLE
Configures deploy script to use rpc workaround

### DIFF
--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -4,12 +4,12 @@ on:
     branches: [main]
 jobs:
   deploy-mainnet:
-    uses: NEARBuilders/bos-workspace/.github/workflows/deploy.yml@main
+    uses: NEARBuilders/bos-workspace/.github/workflows/deploy.yml@rpc-workflow
     with:
       deploy-env: "mainnet"
       app-name: "potlock"
-      deploy-account-address:  potlock.near
+      deploy-account-address: potlock.near
       signer-account-address: potlock.near
       signer-public-key: ed25519:3iWoL6haUT3FGd9KJjwpAS8fLqk7hAdyBX8trD3vSh6C
     secrets:
-      SIGNER_PRIVATE_KEY:  ${{ secrets.SIGNER_PRIVATE_KEY }}
+      SIGNER_PRIVATE_KEY: ${{ secrets.SIGNER_PRIVATE_KEY }}


### PR DESCRIPTION
This set's up the git workflow to use the workflow on [bos-workspace/rpc-workflow](https://github.com/NEARBuilders/bos-workspace/blob/rpc-workflow/.github/workflows/deploy.yml) branch