### PR TITLE
Learn more button test on pots tab

### DIFF
--- a/playwright-tests/tests/pots.spec.js
+++ b/playwright-tests/tests/pots.spec.js
@@ -48,8 +48,14 @@ test.describe("Admin is logged in", () => {
   });
 });
 
-test("clicking learn more button should...", async ({ page }) => {
-  // TODO:
+test("clicking learn more button should redirect to wtfisqr.com", async ({ page }) => {
+  const newTabPromise = page.waitForEvent("popup");
+
+  await page.getByText("Learn More").click();
+  const newTab = await newTabPromise;
+  await newTab.waitForLoadState();
+
+  await expect(newTab).toHaveURL("https://www.wtfisqf.com/");
 });
 
 test("should show active pots", async ({ page }) => {


### PR DESCRIPTION
Added a test case to check if the learn more button in the pots tab opens a new tab for **wtfisqr.com**

Please find attached test videos generated by Playwright.




https://github.com/PotLock/bos-app/assets/46633374/6a8f236e-886c-44e8-94d1-d807355f9830


https://github.com/PotLock/bos-app/assets/46633374/36ac25ef-1ace-404a-9031-94f8d59d5063

